### PR TITLE
Skip empty pidstat logs

### DIFF
--- a/docker/analyzers/plot-pidstat.py
+++ b/docker/analyzers/plot-pidstat.py
@@ -45,6 +45,13 @@ for f in logfiles:
     node_name = m.group(1)
     df = pd.read_csv(f, sep="\s+")
     stats = df.describe().T
+
+    # in case we're monitoring processes that aren't running on all nodes,
+    # some pidstat logs will simply be empty. In this case, pandas will not
+    # generate a "mean" statistic and we should skip further analysis
+    if "mean" not in stats:
+        continue
+
     raw_row = stats[(stats.index == prop)]
     the_row = raw_row.rename(index={prop: node_name})
 


### PR DESCRIPTION
When plotting the pidstat logs from all nodes, some nodes may have empty logs. This is the case when we're monitoring processes that aren't running on all nodes. In this case, pandas will not generate a "mean" statistic and trying to generate the plot will result in a `KeyError`. So when "mean" is not found in the index of the stats, we should skip further analysis.